### PR TITLE
Downloads UNDP life tables.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,3 +13,9 @@ RoxygenNote: 7.1.1
 Suggests: 
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
+Imports: 
+    curl,
+    base,
+    rvest,
+    xml2,
+    readxl

--- a/R/download_lifetables.R
+++ b/R/download_lifetables.R
@@ -9,7 +9,7 @@
 #' 
 #' Here is the terms of use for all UN produced data: https://www.un.org/en/about-us/terms-of-use.
 #' Please look through before downloading the data.
-#' 
+#' Requires 
 #' @param year Year increment for calculations, either 2.5 or 1. Input as string or integer.
 #' @param type "Abridged" or "complete" life tables. 
 #' Input can be a single letter a or c or abridged/complete. 
@@ -39,7 +39,8 @@ download_undp_life_table <- function(year = 1, type = "complete", path) {
   htmlcode = xml2::read_html(url)
   
   # find the relevant url to download the lifetable you're looking for 
-  nodes=rvest::html_nodes(htmlcode,xpath=paste0('//*[contains(@href, "',text,'")]')) %>% rvest::html_attr("href")
+  nodes<-rvest::html_nodes(htmlcode,xpath=paste0('//*[contains(@href, "',text,'")]'))
+  nodes<-rvest::html_attr(nodes, "href")
   df=as.data.frame(as.character(nodes))
   names(df)="link"
   
@@ -49,3 +50,4 @@ download_undp_life_table <- function(year = 1, type = "complete", path) {
   data<-readxl::read_excel(destfile) # load it into R 
   return(data) # return as dataframe
 }
+mydata<-download_undp_life_table(path=getwd())

--- a/R/download_lifetables.R
+++ b/R/download_lifetables.R
@@ -50,5 +50,3 @@ download_undp_life_table <- function(year = 1, type = "complete", path) {
   data<-readxl::read_excel(destfile) # load it into R 
   return(data) # return as dataframe
 }
-
-

--- a/R/download_lifetables.R
+++ b/R/download_lifetables.R
@@ -19,19 +19,25 @@
 #' @examples
 #' download_undp_life_table(year=2.5, type="A", path="./data/")
 #' download_undp_life_table(2.5, "Complete", "C:/Users/ines/population/data/")
+#' lifetable_2.5_complete <-download_undp_life_table(2.5, "Complete", "C:/Users/ines/population/data/")
 download_undp_life_table <- function(year = 1, type = "complete", path) {
   
   # making sure that the type formatting is converted to the correct format
   type <- tolower(type)
   type <- ifelse(startsWith(type, "a"), "abridged", "complete")
+  
+  # Year=1 and type="Complete" stored at different URL pattern than the rest, so handle this with 
+  # if statement for now.
   if (year==1 & type=="complete"){
     url <- "https://www.un.org/en/development/desa/population/publications/pdf/mortality/EMLT/MLT_UN2011_130_1y_complete.xlsx"
   } else {
     url <- paste0("https://www.un.org/development/desa/pd/sites/www.un.org.development.desa.pd/files/unpd_2011_mlt_130_",
                  year, "y_", type, ".xlsx")
   }
-  destfile<-paste0(path, year, "y_", type, "_lifetable.xlsx")
+  
+  destfile<-paste0(path, year, "y_", type, "_lifetable.xlsx") # save as excel file
   download.file(url, destfile)
+  
   data<-readxl::read_excel(destfile)
   return(data)
 }

--- a/R/download_lifetables.R
+++ b/R/download_lifetables.R
@@ -1,0 +1,37 @@
+#' Get demographic data from UNDP
+#'
+#' This function allows you to download the most recent life tables from the 
+#' UNDP most recent life table estimates. The life tables are downloaded where 
+#' you specify and also returned as a dataframe. If you have previously downloaded
+#' a life table the new life table will override the old one.
+#' 
+#' Note: It is unclear when these will next be updated, and when they do the urls 
+#' in the code need to change as well.
+#' 
+#' @param year Year increment for calculations, either 2.5 or 1. Input as string or integer.
+#' @param type "Abridged" or "complete" life tables. 
+#' Input can be a single letter a or c or abridged/complete. 
+#' Abridged tables are broken into 4 year age groups, complete life tables are computed per year.
+#' @param path Location to save undp life table.
+#' @keywords UNDP, life table, download, population
+#' @return Data frame of life table.
+#' @export
+#' @examples
+#' download_undp_life_table(year=2.5, type="A", path="./data/")
+#' download_undp_life_table(2.5, "Complete", "C:/Users/ines/population/data/")
+download_undp_life_table <- function(year = 1, type = "complete", path) {
+  
+  # making sure that the type formatting is converted to the correct format
+  type <- tolower(type)
+  type <- ifelse(startsWith(type, "a"), "abridged", "complete")
+  if (year==1 & type=="complete"){
+    url <- "https://www.un.org/en/development/desa/population/publications/pdf/mortality/EMLT/MLT_UN2011_130_1y_complete.xlsx"
+  } else {
+    url <- paste0("https://www.un.org/development/desa/pd/sites/www.un.org.development.desa.pd/files/unpd_2011_mlt_130_",
+                 year, "y_", type, ".xlsx")
+  }
+  destfile<-paste0(path, year, "y_", type, "_lifetable.xlsx")
+  download.file(url, destfile)
+  data<-readxl::read_excel(destfile)
+  return(data)
+}

--- a/R/download_lifetables.R
+++ b/R/download_lifetables.R
@@ -5,7 +5,7 @@
 #' here (https://www.un.org/development/desa/pd/data/model-life-tables). 
 #' The life tables are downloaded where you specify and also returned as a 
 #' dataframe. If you have previously downloaded a life table the new life table 
-#' will override the old one.
+#' will override the old one. 
 #' 
 #' Here is the terms of use for all UN produced data: https://www.un.org/en/about-us/terms-of-use.
 #' Please look through before downloading the data.
@@ -17,7 +17,7 @@
 #' @param path Location to save undp life table.
 #' 
 #' @keywords UNDP, life table, download, population
-#' @return Data frame of life table.
+#' @return List of life table.
 #' @export
 #' 
 #' @examples
@@ -45,9 +45,10 @@ download_undp_life_table <- function(year = 1, type = "complete", path) {
   names(df)="link"
   
   destfile<-paste0(path, year, "y_", type, "_lifetable.xlsx") # path of file + name, i.e. 1y_abridged.xlsx
-  download.file(df$link[1], destfile) # download the url that matches the string found, in the destination specified
+  curl::curl_download(df$link[1], destfile) # download the url that matches the string found, in the destination specified
   
   data<-readxl::read_excel(destfile) # load it into R 
   return(data) # return as dataframe
 }
-mydata<-download_undp_life_table(path=getwd())
+
+

--- a/R/download_lifetables.R
+++ b/R/download_lifetables.R
@@ -1,9 +1,14 @@
 #' Get demographic data from UNDP
 #'
 #' This function allows you to download the most recent life tables from the 
-#' UNDP most recent life table estimates. The life tables are downloaded where 
-#' you specify and also returned as a dataframe. If you have previously downloaded
-#' a life table the new life table will override the old one.
+#' UNDP most recent life table estimates, from 
+#' here (https://www.un.org/development/desa/pd/data/model-life-tables). 
+#' The life tables are downloaded where you specify and also returned as a 
+#' dataframe. If you have previously downloaded a life table the new life table 
+#' will override the old one.
+#' 
+#' Here is the terms of use for all UN produced data: https://www.un.org/en/about-us/terms-of-use.
+#' Please look through before downloading the data.
 #' 
 #' Note: It is unclear when these will next be updated, and when they do the urls 
 #' in the code need to change as well.
@@ -13,13 +18,16 @@
 #' Input can be a single letter a or c or abridged/complete. 
 #' Abridged tables are broken into 4 year age groups, complete life tables are computed per year.
 #' @param path Location to save undp life table.
+#' 
 #' @keywords UNDP, life table, download, population
 #' @return Data frame of life table.
 #' @export
+#' 
 #' @examples
 #' download_undp_life_table(year=2.5, type="A", path="./data/")
 #' download_undp_life_table(2.5, "Complete", "C:/Users/ines/population/data/")
 #' lifetable_2.5_complete <-download_undp_life_table(2.5, "Complete", "C:/Users/ines/population/data/")
+
 download_undp_life_table <- function(year = 1, type = "complete", path) {
   
   # making sure that the type formatting is converted to the correct format

--- a/R/download_lifetables.R
+++ b/R/download_lifetables.R
@@ -1,12 +1,13 @@
-#' Get demographic data from UNDP
+#' Get model life tables from UNDP
 #'
-#' This function allows you to download the most recent life tables from the 
-#' UNDP most recent life table estimates, from 
-#' here (https://www.un.org/development/desa/pd/data/model-life-tables). 
-#' The life tables are downloaded where you specify and also returned as a 
+#' This function allows you to download the model life tables from the 
+#' UNDP, available here (https://www.un.org/development/desa/pd/data/model-life-tables). 
+#' The life tables are downloaded to a temporary file and returned as a 
 #' dataframe. If you have previously downloaded a life table the new life table 
 #' will override the old one. 
-#' 
+#'
+#'big changes 
+#'
 #' Here is the terms of use for all UN produced data: https://www.un.org/en/about-us/terms-of-use.
 #' Please look through before downloading the data.
 #' Requires 
@@ -25,7 +26,7 @@
 #' download_undp_life_table(2.5, "Complete", "C:/Users/ines/population/data/")
 #' lifetable_2.5_complete <-download_undp_life_table(2.5, "Complete", "C:/Users/ines/population/data/")
 
-download_undp_life_table <- function(year = 1, type = "complete", path) {
+download_undp_life_table <- function(year = 1, type = "complete") {
   
   # making sure that the type formatting is converted to the correct format
   type <- tolower(type)
@@ -44,9 +45,12 @@ download_undp_life_table <- function(year = 1, type = "complete", path) {
   df=as.data.frame(as.character(nodes))
   names(df)="link"
   
-  destfile<-paste0(path, year, "y_", type, "_lifetable.xlsx") # path of file + name, i.e. 1y_abridged.xlsx
-  curl::curl_download(df$link[1], destfile) # download the url that matches the string found, in the destination specified
-  
-  data<-readxl::read_excel(destfile) # load it into R 
+  #destfile<-paste0(path, year, "y_", type, "_lifetable.xlsx") # path of file + name, i.e. 1y_abridged.xlsx
+  #curl::curl_download(df$link[1], destfile) # download the url that matches the string found, in the destination specified
+  tmp<-tempfile()
+  curl::curl_download(df$link[1], tmp)
+  #data<-readxl::read_excel(destfile) # load it into R 
+  data<-readxl::read_excel(tmp)
   return(data) # return as dataframe
 }
+


### PR DESCRIPTION
Function reads and detects all urls on the website UNDP life table website, and downloads the excel files that correspond to users requests for table specifications. If the original URL or the formatting of the name of the excel files changes, we will need an update.

Further work:
- change this pull request from a forked branch to directly working on main - might need admin access for that, if we want to set up a process without review
- change DESCRIPTION file in this pull request
- convert Mx to death rates by pre-specified age bands, and have them be call-able by country
- Also add birth rate calculation
- Finally, add population estimates over time

Wish list later:
- add a helper function that iteratively changes population with time, where time is specified by year

